### PR TITLE
Fix: Validate composer.json and composer.lock in before_install section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ php:
   - 5.4
   - 5.5
   - 5.6
+before_install:
+  - composer self-update
+install:
+  - composer install
 before_script:
   - phpenv config-add phpconfig.ini
-  - composer self-update
-  - composer install
 script:
   - vendor/bin/codecept run
 notfications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.6
 before_install:
   - composer self-update
+  - composer validate
 install:
   - composer install
 before_script:


### PR DESCRIPTION
Blocked by #15.

This PR
- [x] cherry-picks 4cb77f4
- [x] validates `composer.json` and `composer.lock` in the `before_install` section on Travis

:person_with_pouting_face: Current build is erroring because of an extra trailing `,` in `composer.json`. On a separate note, `composer.lock` is not up-to-date with the latest changes in `composer.json`.

Running

```
$ composer validate
```

helps detect these issues.
