### PR TITLE
Fix: Ignore bin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin/
 vendor
 .idea
 


### PR DESCRIPTION
This PR
- [x] adds the `bin` directory to `.gitignore`

:information_desk_person: When we install dependencies, we end up with untracked files as scripts are copied into `bin`, see [`composer.json`](https://github.com/settermjd/podcast-site/blob/develop/composer.json#L40-L42).
